### PR TITLE
Use instanceId filter for faster loading

### DIFF
--- a/searchers/ec2_instances.go
+++ b/searchers/ec2_instances.go
@@ -69,7 +69,7 @@ func (s EC2InstanceSearcher) addToWorkflow(wf *aw.Workflow, query string, config
 
 	item := util.NewURLItem(wf, title).
 		Subtitle(subtitle).
-		Arg(fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#Instances:search=%s", *config.Region, *config.Region, *instance.InstanceId)).
+		Arg(fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/v2/home?region=%s#Instances:instanceId=%s", *config.Region, *config.Region, *instance.InstanceId)).
 		Icon(awsworkflow.GetImageIcon("ec2"))
 
 	if strings.HasPrefix(query, "i-") {


### PR DESCRIPTION
The EC2 Console loads much faster for large accounts if the instanceId filter is used instead of the search string.