### PR TITLE
Fix Global Accelerator URL

### DIFF
--- a/console-services.yml
+++ b/console-services.yml
@@ -529,7 +529,7 @@
 - id: globalaccelerator
   name: Global Accelerator
   description: Improve your application’s availability and performance using the AWS Global Network
-  url: https://console.aws.amazon.com/ec2/GlobalAccelerator/home
+  url: https://console.aws.amazon.com/ec2/v2/home#GlobalAcceleratorDashboard
 
 - id: glue
   name: Glue


### PR DESCRIPTION
https://console.aws.amazon.com/ec2/GlobalAccelerator/home -> Unavailable

https://console.aws.amazon.com/ec2/v2/home#GlobalAcceleratorDashboard -> correct URL