### PR TITLE
[ask for help] Handle stacks without description

### DIFF
--- a/searchers/cloudformation_stacks.go
+++ b/searchers/cloudformation_stacks.go
@@ -60,6 +60,9 @@ func (s CloudFormationStackSearcher) addToWorkflow(wf *aw.Workflow, searchArgs s
 	if strings.HasPrefix(title, "awseb-") && tagName != "" {
 		title += fmt.Sprintf(" (%s)", tagName)
 	}
+
+	// This *entity.Description could be undefined, in which case an error occurs.
+	// TODO: fallback to empty string
 	subtitle := *entity.Description
 
 	path := fmt.Sprintf("/cloudformation/home#/stacks/stackinfo?stackId=%s", *entity.StackId)


### PR DESCRIPTION
I have observed an issue when searching for cloudformation stacks that do not have a description. This situation leads to an error.

I have identified the problem and was able to fix it by using the stackname as the subtitle to get it working again.
However, I think the better solution would be to fallback to an empty string or placeholder text in case the stack doesn't have a description. I have not managed to find a way to do this (as I have not used Go before).

I would appreciate any hints on how I can implement this fallback. 