### PR TITLE
fix: Update ElasticSearch link and add opensearch as a new term

### DIFF
--- a/console-services.yml
+++ b/console-services.yml
@@ -973,7 +973,8 @@
   description: Run and Scale Elasticsearch Clusters
   extra_search_terms:
     - elasticsearch
-  url: "/es/home#"
+    - opensearch
+  url: "/esv3/home#"
 
 - id: elastictranscoder
   name: Elastic Transcoder


### PR DESCRIPTION
The previous link doesn't work anymore. AWS also renamed elasticsearch to opensearch.

## Old:
![old](https://user-images.githubusercontent.com/95634348/156346068-ac4c3e38-663c-4b64-88be-9b98892fa314.png)

## New:
![new](https://user-images.githubusercontent.com/95634348/156346095-afd60eb6-d0ac-4f0a-9cd1-0852a701646f.png)

