### PR TITLE
Update console-service.yml for opensearch console URL change

### DIFF
--- a/console-services.yml
+++ b/console-services.yml
@@ -979,7 +979,7 @@
   extra_search_terms:
     - elasticsearch
     - opensearch
-  url: "/esv3/home#"
+  url: "/aos/home#"
 
 - id: elastictranscoder
   name: Elastic Transcoder


### PR DESCRIPTION
Update console-service.yml for opensearch console URL change

Recently, the opensearch console's URL has changed, causing access issues. To resolve this, the console-service.yml file has been updated.